### PR TITLE
fix: remove obsolete version and replace image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,6 @@
-version: '3'
 services:
   nginx-proxy:
-    image: jwilder/nginx-proxy
+    image: nginxproxy/nginx-proxy
     container_name: nginx-proxy
     restart: unless-stopped
     ports:


### PR DESCRIPTION
* Remove obsolete `version` key to get rid of warnings https://docs.docker.com/compose/compose-file/04-version-and-name/
* Change `nginx-proxy` Docker image to the one from the official Docker account for consistency with `nginxproxy/acme-companion`