### PR TITLE
Add ROS topic relay docs and limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,6 @@ Every Relay server needs a unique wallet to participate in the [posemesh economy
 - [Troubleshooting](docs/troubleshooting.md)
 - [Admin Endpoints](docs/admin-endpoints.md)
 - [Entity Component System](docs/entity-component-system.md)
+- [ROS Topic Relay](docs/ros-topic-relay.md)
 - [Metrics](docs/metrics.md)
 - [Configuration](docs/configuration.md)
-

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -60,24 +60,25 @@ var (
 var _ = reflect.TypeOf(config{})
 
 type config struct {
-	Addr               string             `cli:""        env:"HAGALL_ADDR"                  help:"Listening address for client connections."`
-	AdminAddr          string             `cli:""        env:"HAGALL_ADMIN_ADDR"            help:"Admin listening address."`
-	PublicEndpoint     string             `cli:""        env:"HAGALL_PUBLIC_ENDPOINT"       help:"The public endpoint where this Hagall server is reachable."`
-	PrivateKey         string             `cli:""        env:"HAGALL_PRIVATE_KEY"           help:"The private key of a Hagall server-unique Ethereum-compatible wallet."`
-	PrivateKeyFile     string             `cli:""        env:"HAGALL_PRIVATE_KEY_FILE"      help:"The file that contains the private key of a Hagall server-unique Ethereum-compatible wallet."`
-	LogLevel           string             `cli:""        env:"HAGALL_LOG_LEVEL"             help:"Log level (debug|info|warning|error)."`
-	LogIndent          bool               `cli:""        env:"HAGALL_LOG_INDENT"            help:"Indent logs."`
-	SyncClockInterval  time.Duration      `cli:",hidden" env:"HAGALL_SYNC_CLOCK_INTERVAL"   help:"Client sync clock (heartbeat) message interval."`
-	ClientIdleTimeout  time.Duration      `cli:",hidden" env:"HAGALL_CLIENT_IDLE_TIMEOUT"   help:"Time until an idle client will be disconnected"`
-	FrameDuration      time.Duration      `cli:",hidden" env:"HAGALL_FRAME_DURATION"        help:"The duration of a session frame."`
-	LogSummaryInterval time.Duration      `cli:",hidden" env:"HAGALL_LOG_SUMMARY_INTERVAL"  help:"The duration between each log summary by connection."`
-	HDS                hdsConfig          `cli:",hidden" env:"-"                            help:"HDS configuration."`
-	Events             eventsConfig       `cli:",hidden" env:"-"                            help:"Event pusher configuration."`
-	FeatureFlags       []string           `cli:",hidden" env:"HAGALL_FEATURE_FLAGS"         help:"Comma separated feature flags"`
-	NCSEndpoint        string             `cli:",hidden" env:"HAGALL_NCS_ENDPOINT"          help:"Network Credit Service Endpoint."`
-	Version            bool               `cli:""        env:"-"                            help:"Show version."`
-	Help               bool               `cli:""        env:"-"                            help:"Show help."`
-	ClockChecker       clockCheckerConfig `cli:""        env:"-"                            help:"Clock (time skew) checker configuration."`
+	Addr                 string             `cli:""        env:"HAGALL_ADDR"                    help:"Listening address for client connections."`
+	AdminAddr            string             `cli:""        env:"HAGALL_ADMIN_ADDR"              help:"Admin listening address."`
+	PublicEndpoint       string             `cli:""        env:"HAGALL_PUBLIC_ENDPOINT"         help:"The public endpoint where this Hagall server is reachable."`
+	PrivateKey           string             `cli:""        env:"HAGALL_PRIVATE_KEY"             help:"The private key of a Hagall server-unique Ethereum-compatible wallet."`
+	PrivateKeyFile       string             `cli:""        env:"HAGALL_PRIVATE_KEY_FILE"        help:"The file that contains the private key of a Hagall server-unique Ethereum-compatible wallet."`
+	LogLevel             string             `cli:""        env:"HAGALL_LOG_LEVEL"               help:"Log level (debug|info|warning|error)."`
+	LogIndent            bool               `cli:""        env:"HAGALL_LOG_INDENT"              help:"Indent logs."`
+	SyncClockInterval    time.Duration      `cli:",hidden" env:"HAGALL_SYNC_CLOCK_INTERVAL"     help:"Client sync clock (heartbeat) message interval."`
+	ClientIdleTimeout    time.Duration      `cli:",hidden" env:"HAGALL_CLIENT_IDLE_TIMEOUT"     help:"Time until an idle client will be disconnected"`
+	FrameDuration        time.Duration      `cli:",hidden" env:"HAGALL_FRAME_DURATION"          help:"The duration of a session frame."`
+	LogSummaryInterval   time.Duration      `cli:",hidden" env:"HAGALL_LOG_SUMMARY_INTERVAL"    help:"The duration between each log summary by connection."`
+	CustomMessageMaxSize int                `cli:",hidden" env:"HAGALL_CUSTOM_MESSAGE_MAX_SIZE" help:"Maximum custom message body size in bytes."`
+	HDS                  hdsConfig          `cli:",hidden" env:"-"                              help:"HDS configuration."`
+	Events               eventsConfig       `cli:",hidden" env:"-"                              help:"Event pusher configuration."`
+	FeatureFlags         []string           `cli:",hidden" env:"HAGALL_FEATURE_FLAGS"           help:"Comma separated feature flags"`
+	NCSEndpoint          string             `cli:",hidden" env:"HAGALL_NCS_ENDPOINT"            help:"Network Credit Service Endpoint."`
+	Version              bool               `cli:""        env:"-"                              help:"Show version."`
+	Help                 bool               `cli:""        env:"-"                              help:"Show help."`
+	ClockChecker         clockCheckerConfig `cli:""        env:"-"                              help:"Clock (time skew) checker configuration."`
 }
 
 type hdsConfig struct {
@@ -105,14 +106,15 @@ type clockCheckerConfig struct {
 
 func main() {
 	conf := config{
-		Addr:               ":4000",
-		AdminAddr:          ":18190",
-		PublicEndpoint:     "http://localhost:4000",
-		LogLevel:           logs.InfoLevel.String(),
-		SyncClockInterval:  time.Second * 5,
-		ClientIdleTimeout:  time.Minute * 5,
-		FrameDuration:      time.Millisecond * 15,
-		LogSummaryInterval: time.Minute,
+		Addr:                 ":4000",
+		AdminAddr:            ":18190",
+		PublicEndpoint:       "http://localhost:4000",
+		LogLevel:             logs.InfoLevel.String(),
+		SyncClockInterval:    time.Second * 5,
+		ClientIdleTimeout:    time.Minute * 5,
+		FrameDuration:        time.Millisecond * 15,
+		LogSummaryInterval:   time.Minute,
+		CustomMessageMaxSize: 256 * 1024,
 		HDS: hdsConfig{
 			Endpoint:             "https://hds.auki.network",
 			RegistrationInterval: time.Second * 15,
@@ -263,9 +265,10 @@ func main() {
 					&odal.Module{},
 					&dagaz.Module{},
 				},
-				FeatureFlags: featureflag.New(conf.FeatureFlags),
-				ReceiptChan:  receiptChan,
-				PrivateKey:   privateKey,
+				FeatureFlags:         featureflag.New(conf.FeatureFlags),
+				CustomMessageMaxSize: conf.CustomMessageMaxSize,
+				ReceiptChan:          receiptChan,
+				PrivateKey:           privateKey,
 			}
 			h := hwebsocket.HandlerWithLogs(rh, conf.LogSummaryInterval)
 			h = hwebsocket.HandlerWithMetrics(h, conf.PublicEndpoint)

--- a/docs/ros-topic-relay.md
+++ b/docs/ros-topic-relay.md
@@ -1,0 +1,86 @@
+# ROS Topic Relay
+
+Relay can carry ROS2 pub/sub traffic through the existing session-scoped
+`CustomMessage` path. This keeps the relay transport unchanged while allowing
+robots and operators on different networks to exchange opaque ROS2 topic
+payloads after they join the same Relay session.
+
+## Transport
+
+Clients publish ROS topic messages as `hagallpb.CustomMessage` frames:
+
+- `Body` contains an encoded ROS topic envelope.
+- `ParticipantIds` is optional. When set, Relay forwards only to those
+  participant ids. When empty, Relay fans out to every other participant in the
+  same session.
+- Relay stamps the broadcast with the sender participant id in
+  `CustomMessageBroadcast.ParticipantId`.
+
+Relay does not parse, validate, or transform ROS payload bytes. Clients are
+responsible for choosing a body encoding, such as JSON, protobuf, or CDR wrapped
+by an application-level envelope.
+
+## Recommended Envelope
+
+The recommended application-level envelope fields are:
+
+```json
+{
+  "topic": "/cmd_vel",
+  "ros_message_type": "geometry_msgs/msg/Twist",
+  "payload_encoding": "cdr",
+  "payload": "<base64 serialized ROS2 message>",
+  "target_participant_ids": [42]
+}
+```
+
+Relay derives `origin_participant_id` from the authenticated session
+participant and adds it to the broadcast metadata. Clients should prefer the
+broadcast metadata over trusting a client-supplied origin field.
+
+## Session Model
+
+ROS topic messages are isolated by Relay session:
+
+1. The operator and robot both send `ParticipantJoinRequest`.
+2. The publisher sends `CustomMessage` with the ROS envelope in `Body`.
+3. Relay broadcasts inside that same session only.
+4. Participants in other sessions never receive the broadcast.
+
+## Size Limit
+
+The default custom message body limit is 256 KiB. This is large enough for small
+control and telemetry topics while still bounding relay memory and bandwidth
+exposure. Oversized messages are rejected with `ERROR_CODE_TOO_LARGE`.
+
+Operators can override the limit with:
+
+```bash
+HAGALL_CUSTOM_MESSAGE_MAX_SIZE=262144
+```
+
+Large image, point-cloud, bag, service, or action payloads should not be sent
+through this path. Use a storage or streaming transport and send references
+through Relay instead.
+
+## Feature Flag
+
+Set `DISABLE_ROS_TOPIC_RELAY` in `HAGALL_FEATURE_FLAGS` to disable this path:
+
+```bash
+HAGALL_FEATURE_FLAGS=DISABLE_ROS_TOPIC_RELAY
+```
+
+`DISABLE_CUSTOM_MESSAGE_BROADCAST` also disables the underlying broadcast path.
+
+## Operator Walkthrough
+
+1. Start Relay with the default 256 KiB limit, or set
+   `HAGALL_CUSTOM_MESSAGE_MAX_SIZE` explicitly.
+2. Have the operator client and robot client join the same session.
+3. Encode each ROS topic publish into the recommended envelope.
+4. Send it as a `CustomMessage`.
+5. On `CustomMessageBroadcast`, decode `Body`, read
+   `CustomMessageBroadcast.ParticipantId` as the origin participant, and publish
+   the decoded payload onto the local ROS2 topic.
+

--- a/featureflag/flags.go
+++ b/featureflag/flags.go
@@ -10,6 +10,7 @@ const (
 	FlagDisableEntityDeleteBroadcast          Flag = "DISABLE_ENTITY_DELETE_BROADCAST"
 	FlagDisableEntityUpdatePoseBroadcast      Flag = "DISABLE_ENTITY_UPDATE_POSE_BROADCAST"
 	FlagDisableCustomMessageBroadcast         Flag = "DISABLE_CUSTOM_MESSAGE_BROADCAST"
+	FlagDisableRosTopicRelay                  Flag = "DISABLE_ROS_TOPIC_RELAY"
 	FlagDisableEntityComponentAddBroadcast    Flag = "DISABLE_ENTITY_COMPONENT_ADD_BROADCAST"
 	FlagDisableEntityComponentUpdateBroadcast Flag = "DISABLE_ENTITY_COMPONENT_UPDATE_BROADCAST"
 	FlagDisableEntityComponentDeleteBroadcast Flag = "DISABLE_ENTITY_COMPONENT_DELETE_BROADCAST"

--- a/websocket/handler_test.go
+++ b/websocket/handler_test.go
@@ -2,10 +2,6 @@ package websocket
 
 import (
 	"context"
-	"github.com/aukilabs/hagall/modules"
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/crypto"
-	"google.golang.org/protobuf/proto"
 	"testing"
 	"time"
 
@@ -14,8 +10,12 @@ import (
 	hwebsocket "github.com/aukilabs/hagall-common/websocket"
 	"github.com/aukilabs/hagall/featureflag"
 	"github.com/aukilabs/hagall/models"
+	"github.com/aukilabs/hagall/modules"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -1650,8 +1650,24 @@ func TestHandleCustomMessage(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	t.Run("message larger than 10 kB are rejected with error", func(t *testing.T) {
-		clientA, clientB, close := NewTestingEnv(t, newTestHandler())
+	t.Run("message larger than the configured limit is rejected with error", func(t *testing.T) {
+		sessionStore := &models.SessionStore{
+			DiscoveryService: &testClient{},
+		}
+		newHandler := func() Handler {
+			var h Handler = &RealtimeHandler{
+				ClientSyncClockInterval: time.Millisecond * 250,
+				ClientIdleTimeout:       time.Minute,
+				FrameDuration:           time.Millisecond * 50,
+				Sessions:                sessionStore,
+				CustomMessageMaxSize:    customMessageMaxSize,
+			}
+
+			h = HandlerWithLogs(h, time.Millisecond*100)
+			h = HandlerWithMetrics(h, "https://auki-test.com")
+			return h
+		}
+		clientA, clientB, close := NewTestingEnv(t, newHandler)
 		defer close()
 
 		ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*100)
@@ -1735,6 +1751,154 @@ func TestHandleCustomMessage(t *testing.T) {
 				scenario.FilterByType(hagallpb.MsgType_MSG_TYPE_CUSTOM_MESSAGE_BROADCAST),
 			).
 			Run(ctx)
+		require.Error(t, err)
+	})
+
+	t.Run("default limit accepts ros topic sized custom messages", func(t *testing.T) {
+		clientA, clientB, close := NewTestingEnv(t, newTestHandler())
+		defer close()
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+
+		var sessionID string
+
+		err := scenario.NewScenario(clientA).
+			Send(func() hwebsocket.ProtoMsg {
+				return &hagallpb.ParticipantJoinRequest{
+					Type:      hagallpb.MsgType_MSG_TYPE_PARTICIPANT_JOIN_REQUEST,
+					Timestamp: timestamppb.Now(),
+					RequestId: 1,
+				}
+			}).
+			Receive(scenario.FilterByType(
+				hagallpb.MsgType_MSG_TYPE_PARTICIPANT_JOIN_RESPONSE),
+				func(msg hwebsocket.Msg) error {
+					var res hagallpb.ParticipantJoinResponse
+					err := msg.DataTo(&res)
+					require.NoError(t, err)
+
+					sessionID = res.SessionId
+					return err
+				},
+			).
+			Run(ctx)
+		require.NoError(t, err)
+
+		body := make([]byte, customMessageMaxSize+1)
+
+		err = scenario.NewScenario(clientB).
+			Send(func() hwebsocket.ProtoMsg {
+				return &hagallpb.ParticipantJoinRequest{
+					Type:      hagallpb.MsgType_MSG_TYPE_PARTICIPANT_JOIN_REQUEST,
+					Timestamp: timestamppb.Now(),
+					RequestId: 2,
+					SessionId: sessionID,
+				}
+			}).
+			Receive(
+				scenario.FilterByType(hagallpb.MsgType_MSG_TYPE_PARTICIPANT_JOIN_RESPONSE),
+			).
+			Send(func() hwebsocket.ProtoMsg {
+				return &hagallpb.CustomMessage{
+					Type:      hagallpb.MsgType_MSG_TYPE_CUSTOM_MESSAGE,
+					Timestamp: timestamppb.Now(),
+					Body:      body,
+				}
+			}).
+			Run(ctx)
+		require.NoError(t, err)
+
+		err = scenario.NewScenario(clientA).
+			Receive(
+				scenario.FilterByType(hagallpb.MsgType_MSG_TYPE_CUSTOM_MESSAGE_BROADCAST),
+				func(msg hwebsocket.Msg) error {
+					var bc hagallpb.CustomMessageBroadcast
+					err := msg.DataTo(&bc)
+					require.NoError(t, err)
+					require.Len(t, bc.Body, customMessageMaxSize+1)
+					return err
+				},
+			).
+			Run(ctx)
+		require.NoError(t, err)
+	})
+
+	t.Run("ros topic relay feature flag disables custom message delivery", func(t *testing.T) {
+		sessionStore := &models.SessionStore{
+			DiscoveryService: &testClient{},
+		}
+		newHandler := func() Handler {
+			var h Handler = &RealtimeHandler{
+				ClientSyncClockInterval: time.Millisecond * 250,
+				ClientIdleTimeout:       time.Minute,
+				FrameDuration:           time.Millisecond * 50,
+				Sessions:                sessionStore,
+				FeatureFlags:            featureflag.New([]string{string(featureflag.FlagDisableRosTopicRelay)}),
+			}
+
+			h = HandlerWithLogs(h, time.Millisecond*100)
+			h = HandlerWithMetrics(h, "https://auki-test.com")
+			return h
+		}
+		clientA, clientB, close := NewTestingEnv(t, newHandler)
+		defer close()
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+
+		var sessionID string
+
+		err := scenario.NewScenario(clientA).
+			Send(func() hwebsocket.ProtoMsg {
+				return &hagallpb.ParticipantJoinRequest{
+					Type:      hagallpb.MsgType_MSG_TYPE_PARTICIPANT_JOIN_REQUEST,
+					Timestamp: timestamppb.Now(),
+					RequestId: 1,
+				}
+			}).
+			Receive(scenario.FilterByType(
+				hagallpb.MsgType_MSG_TYPE_PARTICIPANT_JOIN_RESPONSE),
+				func(msg hwebsocket.Msg) error {
+					var res hagallpb.ParticipantJoinResponse
+					err := msg.DataTo(&res)
+					require.NoError(t, err)
+
+					sessionID = res.SessionId
+					return err
+				},
+			).
+			Run(ctx)
+		require.NoError(t, err)
+
+		err = scenario.NewScenario(clientB).
+			Send(func() hwebsocket.ProtoMsg {
+				return &hagallpb.ParticipantJoinRequest{
+					Type:      hagallpb.MsgType_MSG_TYPE_PARTICIPANT_JOIN_REQUEST,
+					Timestamp: timestamppb.Now(),
+					RequestId: 2,
+					SessionId: sessionID,
+				}
+			}).
+			Receive(
+				scenario.FilterByType(hagallpb.MsgType_MSG_TYPE_PARTICIPANT_JOIN_RESPONSE),
+			).
+			Send(func() hwebsocket.ProtoMsg {
+				return &hagallpb.CustomMessage{
+					Type:      hagallpb.MsgType_MSG_TYPE_CUSTOM_MESSAGE,
+					Timestamp: timestamppb.Now(),
+					Body:      []byte("ros-topic"),
+				}
+			}).
+			Run(ctx)
+		require.NoError(t, err)
+
+		ctxTimeout, cancelTimeout := context.WithTimeout(context.Background(), time.Millisecond*100)
+		defer cancelTimeout()
+
+		err = scenario.NewScenario(clientA).
+			Receive(scenario.FilterByType(hagallpb.MsgType_MSG_TYPE_CUSTOM_MESSAGE_BROADCAST)).
+			Run(ctxTimeout)
 		require.Error(t, err)
 	})
 

--- a/websocket/realtime.go
+++ b/websocket/realtime.go
@@ -17,7 +17,10 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-const customMessageMaxSize = 10240
+const (
+	customMessageMaxSize        = 10240
+	defaultCustomMessageMaxSize = 256 * 1024
+)
 
 // RealtimeHandler represents a service that manages multiple client connections
 // and relays their actions in realtime.
@@ -39,6 +42,8 @@ type RealtimeHandler struct {
 	Modules []modules.Module
 
 	FeatureFlags featureflag.FeatureFlag
+
+	CustomMessageMaxSize int
 
 	// channel for sending incoming receipts to ReceiptHandler goroutine
 	ReceiptChan chan ncsclient.ReceiptPayload
@@ -423,7 +428,12 @@ func (h *RealtimeHandler) HandleCustomMessage(ctx context.Context, respond hwebs
 			WithTag("msg_type", msg.Type)
 	}
 
-	if len(customMessage.Body) > customMessageMaxSize {
+	maxSize := h.CustomMessageMaxSize
+	if maxSize == 0 {
+		maxSize = defaultCustomMessageMaxSize
+	}
+
+	if len(customMessage.Body) > maxSize {
 		respond.Send(&hagallpb.ErrorResponse{
 			Type:      hagallpb.MsgType_MSG_TYPE_ERROR_RESPONSE,
 			Timestamp: timestamppb.Now(),
@@ -432,21 +442,23 @@ func (h *RealtimeHandler) HandleCustomMessage(ctx context.Context, respond hwebs
 		return nil
 	}
 
-	h.FeatureFlags.IfNotSet(featureflag.FlagDisableCustomMessageBroadcast, func() {
-		customMessageBroadcast := hagallpb.CustomMessageBroadcast{
-			Type:            hagallpb.MsgType_MSG_TYPE_CUSTOM_MESSAGE_BROADCAST,
-			Timestamp:       timestamppb.Now(),
-			OriginTimestamp: customMessage.Timestamp,
-			ParticipantId:   participant.ID,
-			Body:            customMessage.Body,
-		}
+	h.FeatureFlags.IfNotSet(featureflag.FlagDisableRosTopicRelay, func() {
+		h.FeatureFlags.IfNotSet(featureflag.FlagDisableCustomMessageBroadcast, func() {
+			customMessageBroadcast := hagallpb.CustomMessageBroadcast{
+				Type:            hagallpb.MsgType_MSG_TYPE_CUSTOM_MESSAGE_BROADCAST,
+				Timestamp:       timestamppb.Now(),
+				OriginTimestamp: customMessage.Timestamp,
+				ParticipantId:   participant.ID,
+				Body:            customMessage.Body,
+			}
 
-		if len(customMessage.ParticipantIds) != 0 {
-			session.BroadcastTo(participant, &customMessageBroadcast, customMessage.ParticipantIds...)
-			return
-		}
+			if len(customMessage.ParticipantIds) != 0 {
+				session.BroadcastTo(participant, &customMessageBroadcast, customMessage.ParticipantIds...)
+				return
+			}
 
-		session.Broadcast(participant, &customMessageBroadcast)
+			session.Broadcast(participant, &customMessageBroadcast)
+		})
 	})
 	return nil
 }


### PR DESCRIPTION
## Summary

This adds a first iteration of ROS2 topic relay support over the existing session-scoped CustomMessage path.

Changes include:
- Documenting the ROS topic relay flow and recommended payload envelope
- Linking the guide from the README
- Raising the default CustomMessage body limit to 256 KiB
- Adding HAGALL_CUSTOM_MESSAGE_MAX_SIZE for operators
- Adding DISABLE_ROS_TOPIC_RELAY as an operator-facing feature flag
- Covering configured size rejection, larger default payload acceptance, and disabled relay behavior in websocket tests

## Tests

- GOCACHE=/private/tmp/go-build GOMODCACHE=/private/tmp/go-mod GOPROXY=https://goproxy.cn,direct /opt/homebrew/bin/go test ./websocket -run TestHandleCustomMessage
- GOCACHE=/private/tmp/go-build GOMODCACHE=/private/tmp/go-mod GOPROXY=https://goproxy.cn,direct /opt/homebrew/bin/go test ./websocket

## Bounty

This addresses #62. Payment details can be provided privately if this is accepted for the bounty.